### PR TITLE
[bugfix] 더보기 및 접기 버튼 동작하지 않는 문제

### DIFF
--- a/careerlyclonefrontend/src/components/feed/FeedContentComponent.tsx
+++ b/careerlyclonefrontend/src/components/feed/FeedContentComponent.tsx
@@ -49,8 +49,8 @@ const FeedContentComponent = ({
 
   // 댓글 조회 시 게시글 토큰을 param으로 보내서 조회 (?post-tokent=value)
   return (
-    <div className="feed-frame--content" onClick={handleTitleClick}>
-      <div className="feed-title">
+    <div className="feed-frame--content">
+      <div className="feed-title" onClick={handleTitleClick}>
         <p>{feedContentData.title}</p>
       </div>
       <div


### PR DESCRIPTION
상세 페이지로 이동하는 handleTitleClick이 더보기 버튼 동작보다 상위에
있어

더보기 버튼 동작을 덮어버리는 문제가 발생하여 더보기 및 접기 버튼이 동작
않음

handleTitleClick 동작을 더보기 및 접기 동작과 같은 레벨로 내려 해결함